### PR TITLE
chore: removed node modules from backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # dependencies
 /node_modules
+/server/node_modules
 /.pnp
 .pnp.js
 


### PR DESCRIPTION
Updated gitignore to remove node modules from Backend